### PR TITLE
fix: address Trivy vulns and upgrade tool versions

### DIFF
--- a/install-kubectl.sh
+++ b/install-kubectl.sh
@@ -5,7 +5,7 @@ KUBECTL_INSTALL_DIR="${KUBECTL_INSTALL_DIR:-/usr/local/bin}"
 
 
 mkdir -p $KUBECTL_INSTALL_DIR
-for version in ${versions[@]}; do
+for version in $versions; do
   KUBECTL_FILE=$KUBECTL_INSTALL_DIR/kubectl-v$version
   echo "Installing kubectl v$version to $KUBECTL_FILE"
   curl -L https://dl.k8s.io/release/v${version}/bin/linux/amd64/kubectl -o $KUBECTL_FILE


### PR DESCRIPTION
- Ubuntu: add apt-get upgrade step for OS security updates (e.g. libgnutls)
- Azure CLI: upgrade pip to >=25.3 in venv (CVE-2025-8869)
- Go: use 1.22.4, fix install (single RUN, go.dev URL)
- Terraform: 1.6.6 → 1.12.1
- yq: 4.40.5 → 4.52.4
- Node: 20 → 22 LTS, yarn keyring, npm update -g after jsonlint
- kubectl: 1.24–1.26 → 1.30–1.32; fix install-kubectl.sh loop for multiple versions

Made-with: Cursor